### PR TITLE
[BUGFIX] Fixed deprecated filetype configuarion.

### DIFF
--- a/lua/options.lua
+++ b/lua/options.lua
@@ -94,7 +94,7 @@ g.coc_snippet_next = "<Tab>"
 g.coc_snippet_prev = "<S-Tab>"
 
 -- Do not source the default filetype.vim - we use filetype.nvim
-g.did_load_filetypes = 0
+-- As of NeoVim 8.0, filetype.lua is the new default 👍
 g.do_filetype_lua = 1
 
 opt.foldmethod = "expr"

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -20,13 +20,13 @@ return require("packer").startup {
     -- Lua Functions that you don't have to write yourself
     use { "wbthomason/packer.nvim" }
 
-    -- Better/Faster FileType detection
-    use {
-      "nathom/filetype.nvim",
-      setup = function()
-        require("plugins.filetype").setup()
-      end,
-    }
+    --  -- Better/Faster FileType detection */
+    --  use {
+    --    "nathom/filetype.nvim",
+    --    setup = function()
+    --      require("plugins.filetype").setup()
+    --    end,
+    --  }
     -- Easy way to interface with tree-sitter, an incremental parsing system.
     use {
       "nvim-treesitter/nvim-treesitter",
@@ -53,15 +53,6 @@ return require("packer").startup {
         require("plugins.registers").setup()
       end,
     }
-
-    -- use {
-    --   "lewis6991/gitsigns.nvim",
-    --   requires = { "nvim-lua/plenary.nvim" },
-    --   -- tag = 'release' -- To use the latest release
-    --   config = function()
-    --     require("gitsigns").setup()
-    --   end,
-    -- }
 
     -- better QuickFix window for NeoVim
     use { "kevinhwang91/nvim-bqf" }


### PR DESCRIPTION
NeoVim 8.0 release with `filetype.lua` as default FT matching. Did not replace the old custom FT matching yet.